### PR TITLE
Force proprietary nvidia kmod (CI built open, breaking Pascal)

### DIFF
--- a/build-nvidia.sh
+++ b/build-nvidia.sh
@@ -74,6 +74,19 @@ if [ "${#kmodsrcs[@]}" -ne 1 ]; then
     echo "build-nvidia: expected exactly one kmod srpm in /usr/src/akmods, found ${#kmodsrcs[@]}" >&2
     exit 1
 fi
+
+# Force the PROPRIETARY kmod variant. The kmod spec otherwise does GPU "runtime
+# detection" (open vs proprietary); on a headless builder (CI, no GPU) that picks
+# the OPEN module, which does NOT support pre-Turing GPUs — the Pascal GTX 1070
+# then fails at boot ("not supported by open nvidia.ko ... GSP"). Defining
+# _without_kmod_nvidia_detect skips detection so the default (proprietary) kernel
+# tree is built. akmodsbuild's rpmbuild reads /etc/rpm/macros.* normally. An
+# -open variant is intentionally left to build the open module.
+if [ "${NVIDIA_DRIVER}" != "nvidia-open" ]; then
+    mkdir -p /etc/rpm
+    echo '%_without_kmod_nvidia_detect 1' > /etc/rpm/macros.zz-nvidia-proprietary
+fi
+
 builddir="$(mktemp -d)"
 chown akmods:akmods "${builddir}"
 runuser -u akmods -- /usr/sbin/akmodsbuild --quiet \

--- a/check-build-nvidia.sh
+++ b/check-build-nvidia.sh
@@ -17,8 +17,24 @@ esac
 ### 1. Driver packages installed and the kmod actually built
 rpm -q "akmod-${NVIDIA_DRIVER}" >/dev/null
 rpm -q "${CUDA_PKG}" >/dev/null
-if ! find "/usr/lib/modules/${KERNEL}" -name 'nvidia.ko*' | grep -q .; then
+ko="$(find "/usr/lib/modules/${KERNEL}" -name 'nvidia.ko*' | head -1)"
+if [ -z "${ko}" ]; then
     echo "check-build-nvidia: nvidia.ko missing for ${KERNEL}" >&2
+    exit 1
+fi
+
+### 1b. Built the requested variant (open vs proprietary)?
+# The kmod spec auto-detects the GPU to choose open/proprietary; on a headless
+# builder that picks OPEN, which silently breaks pre-Turing GPUs (Pascal etc.).
+# Assert the module license matches the branch so a wrong variant fails the build
+# here, not at the user's boot. proprietary = "NVIDIA", open = "Dual MIT/GPL".
+lic="$(modinfo "${ko}" 2>/dev/null | sed -n 's/^license:[[:space:]]*//p')"
+case "${NVIDIA_DRIVER}" in
+    *-open) want="Dual MIT/GPL" ;;
+    *)      want="NVIDIA" ;;
+esac
+if [ "${lic}" != "${want}" ]; then
+    echo "check-build-nvidia: kmod license '${lic}' != expected '${want}' for ${NVIDIA_DRIVER} (open/proprietary mismatch)" >&2
     exit 1
 fi
 


### PR DESCRIPTION
The 580xx kmod spec auto-detects the GPU to pick open vs proprietary; the headless CI builder picked **open**, which doesn't support the Pascal GTX 1070 (boot fails: "not supported by open nvidia.ko ... GSP", drops to EFI framebuffer). Define `_without_kmod_nvidia_detect` to force proprietary, and add a `check-build` guard asserting the kmod license matches the requested branch so a wrong variant fails the build, not the boot.