### PR TITLE
ci: drop runner disk-cleanup step (matches ublue-os/main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,6 @@ jobs:
       - name: Checkout Push to Registry action
         uses: actions/checkout@v6
 
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@v9
-
       # Effective Fedora base tag: the workflow_dispatch override if given, else
       # the Containerfile's SOURCE_TAG (single source of truth). A "transient"
       # build is a manual override to a Fedora version other than the repo's


### PR DESCRIPTION
ublue-os/remove-unwanted-software@v9 has been 404'ing on codeload for days, breaking every scheduled base build. ublue-os/main dropped runner disk-cleanup entirely in 2026-02 (after cycling through three approaches) and now runs every build, including NVIDIA, on the stock ubuntu-24.04 ~14GB free disk — our sericea-main build is a strict subset of theirs, so it fits too. The PR build validates end-to-end before merge.